### PR TITLE
Fix incorrect JSON parameter name in GET text api request

### DIFF
--- a/src/builders/text-request.builder.ts
+++ b/src/builders/text-request.builder.ts
@@ -115,7 +115,11 @@ export class TextGenerationGetRequestBuilder extends BaseTextRequestBuilder<Text
 		const searchParams = new URLSearchParams(
 			Object.entries(queryParams)
 				.filter(([_, v]) => v !== undefined)
-				.map(([k, v]) => [k, v.toString()])
+				.map(([k, v]) => {
+					if (k === "jsonMode") return ["json", v.toString()]
+
+					return [k, v.toString()]
+				})
 		)
 
 		return `${this.baseUrl}/prompt/${prompt}?${searchParams}`


### PR DESCRIPTION
- Corrects the query parameter name from jsonMode to json in text requests
- Aligns with API documentation requiring "json" parameter for response format
- Maintains backward compatibility with existing jsonMode property in request params